### PR TITLE
power_switch: dont load timeouts after boot

### DIFF
--- a/firmware/shc_powerswitch/shc_powerswitch.c
+++ b/firmware/shc_powerswitch/shc_powerswitch.c
@@ -441,7 +441,7 @@ int main(void)
 	// read (saved) switch state from before the eventual powerloss
 	for (i = 0; i < SWITCH_COUNT; i++)
 	{
-		switchRelais(i, e2p_powerswitch_get_switchstate(i), e2p_powerswitch_get_switchtimeout(i), true);
+		switchRelais(i, e2p_powerswitch_get_switchstate(i), 0, true);
 	}
 
 	rfm12_init();


### PR DESCRIPTION
loading the timeoute after boot will result in this behavior:

```
Before decryption: 1b 63 c4 e3 ca 36 7f 9b 4b d3 53 e0 c5 e3 20 b8
Decrypted bytes: f1 43 4a 6f 00 00 09 97 b2 00 a0 2c 20 01 40 00
Packet Data: SenderID:0;PacketCounter:39291;MessageType:2;ReceiverID:10;MessageGroupID:1;MessageID:6;Pos:0;On:1;TimeoutSec:10;
Sending AckStatus
Sending GPIO DigitalPortTimeout Status:
Switch 1 ON (Timeout: 5s)
Switch 2 OFF
Switch 3 OFF
Switch 4 OFF
Switch 5 OFF
Switch 6 OFF
Before decryption: c4 2f 30 06 f8 b4 35 69 1d 66 bf e5 b0 86 5d 69
Decrypted bytes: b9 07 78 b1 00 b0 0f 95 78 02 30 00 00 00 00 00
Timeout! Switching relais 1 to 0 with timeout 0s.
Sending GPIO DigitalPortTimeout Status:
Switch 1 OFF
Switch 2 OFF
Switch 3 OFF
Switch 4 OFF
Switch 5 OFF
Switch 6 OFF

smarthomatic Power Switch v0.0.0 (00000000)
(c) 2013..2014 Uwe Freese, www.smarthomatic.org
The CPU speed was adjusted by +1/1000 as set in OSCCAL_MODE byte.
DeviceID: 10
PacketCounter: 1800
Switch 1 OFF
Switch 2 OFF
Switch 3 OFF
Switch 4 OFF
Switch 5 OFF
Switch 6 OFF
Last received base station PacketCounter: 39291

Switching relais 1 to 0 with timeout 10s.
Switching relais 2 to 0 with timeout 0s.
Switching relais 3 to 0 with timeout 0s.
Switching relais 4 to 0 with timeout 0s.
Switching relais 5 to 0 with timeout 0s.
Switching relais 6 to 0 with timeout 0s.
Sending GPIO DigitalPortTimeout Status:
Switch 1 OFF (Timeout: 5s)
Switch 2 OFF
Switch 3 OFF
Switch 4 OFF
Switch 5 OFF
Switch 6 OFF
Send DeviceInfo: DeviceType 40, v0.0.0 (00000000)
Timeout! Switching relais 1 to 1 with timeout 0s.
Sending GPIO DigitalPortTimeout Status:
Switch 1 ON
Switch 2 OFF
Switch 3 OFF
Switch 4 OFF
Switch 5 OFF
Switch 6 OFF
```

i expect the switch 1 to be off. so we dont need to load timeouts.