### PR TITLE
dont update pin state when di trigger mode in off

### DIFF
--- a/firmware/shc_envsensor/shc_envsensor.c
+++ b/firmware/shc_envsensor/shc_envsensor.c
@@ -188,7 +188,7 @@ void remember_di_state(void)
 	
 	for (i = 0; i < 8; i++)
 	{
-		if (di[i].pin != DI_UNUSED)
+		if (di[i].pin != DI_UNUSED && di[i].mode != DIGITALINPUTTRIGGERMODE_OFF)
 		{
 			uint8_t stat = getPinStatus(di[i].port, di[i].pin);
 			di[i].meas.val = stat;


### PR DESCRIPTION
if we get the pin state for pins with trigger mode off, we will get it when the pullup resistor is not up.