### PR TITLE
Removed obsolete check in main loop

### DIFF
--- a/firmware/shc_envsensor/shc_envsensor.c
+++ b/firmware/shc_envsensor/shc_envsensor.c
@@ -1049,11 +1049,7 @@ int main(void)
 		// search for value to send with avgInt reached
 		bool send = true;
 		
-		if (pin_wakeup && !di_change) // don't send update if pin level changed in "wrong" direction
-		{
-			send = false;
-		}
-		else if (di_change)
+		if (di_change)
 		{
 			prepare_digitalport();
 		}


### PR DESCRIPTION
Please take a look at the corresponding Karnaugh-Veitch-Diagramm:
pin_wakeup di_change prepare_digitalport
	0		0		0
	0		1		1
	1		0		0
	1		1		1

So the removed check does not change any behaviour.